### PR TITLE
IO-2773: fix OData to work with the new version of Chocolatey

### DIFF
--- a/lib/odata/query.rb
+++ b/lib/odata/query.rb
@@ -91,6 +91,14 @@ module OData
       self
     end
 
+    # Add search term criteria to query.
+    # @param value
+    # @return [self]
+    def search_term(value)
+      criteria_set[:search_term] = value
+      self
+    end
+
     # Add inline count criteria to query.
     # Not Supported in CRM2011
     # @return [self]
@@ -146,13 +154,15 @@ module OData
           orderby:      [],
           skip:         0,
           top:          0,
-          inline_count: false
+          inline_count: false,
+          search_term:   nil
       }
     end
 
     def assemble_criteria
       criteria = [
         filter_criteria,
+        search_term_criteria(:search_term),
         list_criteria(:orderby),
         list_criteria(:expand),
         list_criteria(:select),
@@ -177,6 +187,13 @@ module OData
     # inlinecount not supported by Microsoft CRM 2011
     def inline_count_criteria
       criteria_set[:inline_count] ? '$inlinecount=allpages' : nil
+    end
+
+    def search_term_criteria(name)
+      search = criteria_set[name].present? == 0 ? nil : "searchTerm='#{criteria_set[name]}'"
+      if search.present?
+        search += '&includePrerelease=false'
+      end
     end
 
     def paging_criteria(name)

--- a/lib/odata/query/result.rb
+++ b/lib/odata/query/result.rb
@@ -61,16 +61,17 @@ module OData
       end
 
       def next_page_url
-        return unless next_page && next_page.attributes['href']
+        next_page_value = next_page
+        return unless next_page_value && next_page_value.attributes['href']
 
         # We used to get the url in http format, then it changed
         # to https. Let's remove both
         http_verison =  service.service_url.sub('https://', 'http://')
         https_version = service.service_url.sub('http://', 'https://')
-        next_page.attributes['href']
-                 .value
-                 .gsub(http_verison, '')
-                 .gsub(https_version, '')
+        next_page_value.attributes['href']
+                       .value
+                       .gsub(http_verison, '')
+                       .gsub(https_version, '')
       end
     end
   end

--- a/lib/odata/query/result.rb
+++ b/lib/odata/query/result.rb
@@ -20,7 +20,10 @@ module OData
       # @return [OData::Entity] each entity in turn for the query result
       MAX_EXECUTIONS = 100
       def each(&block)
-        finished_processing = false
+        last_processed_url = next_page_url
+        process_results(&block)
+
+        finished_processing = last_processed_url == next_page_url
         execution_count = 0
         until finished_processing
           last_processed_url = next_page_url
@@ -58,7 +61,8 @@ module OData
       end
 
       def next_page_url
-        return unless next_page
+        return unless next_page && next_page.attributes['href']
+
         # We used to get the url in http format, then it changed
         # to https. Let's remove both
         http_verison =  service.service_url.sub('https://', 'http://')

--- a/lib/odata/service.rb
+++ b/lib/odata/service.rb
@@ -124,6 +124,14 @@ module OData
     # @param additional_options [Hash] options to pass to Typhoeus
     # @return [Typhoeus::Response]
     def execute(url_chunk, additional_options = {}, escaped = false)
+      # There must be a better way to do it,
+      # but we only use it for Chocolatey, so it won't break anything else
+      # This just forces us to use Search endpoint for searching through
+      # Chocolatey instead of Packages.
+      if url_chunk && url_chunk.starts_with?('Packages?')
+        url_chunk = url_chunk.gsub('Packages?', 'Search()?')
+      end
+
       url = if escaped
         "#{URI.escape(service_url)}/#{url_chunk}"
       else

--- a/lib/odata/service.rb
+++ b/lib/odata/service.rb
@@ -123,9 +123,15 @@ module OData
     # @param url_chunk [to_s] string to append to service url
     # @param additional_options [Hash] options to pass to Typhoeus
     # @return [Typhoeus::Response]
-    def execute(url_chunk, additional_options = {})
+    def execute(url_chunk, additional_options = {}, escaped = false)
+      url = if escaped
+        "#{URI.escape(service_url)}/#{url_chunk}"
+      else
+        URI.escape("#{service_url}/#{url_chunk}")
+      end
+
       request = ::Typhoeus::Request.new(
-          URI.escape("#{service_url}/#{url_chunk}"),
+          url,
           options[:typhoeus].merge({ method: :get
                                    })
                             .merge(additional_options)


### PR DESCRIPTION
Updates our fork to use a different OData endpoint.

Why: Chocolatey API changed and we can no longer search through packages using the old API. The new endpoint is not guaranteed to stay the same, but it works now. The only other alternative is to use their official .net choco client.
